### PR TITLE
ros timestamp fix (livox_lidar.cpp)

### DIFF
--- a/livox_ros_driver/livox_lidar.cpp
+++ b/livox_ros_driver/livox_lidar.cpp
@@ -423,9 +423,8 @@ static uint32_t PublishPointcloud2(StoragePacketQueue* queue, uint32_t packet_nu
     }
 
     if (!cloud->width) {
-      //cloud->header.stamp = ros::Time(timestamp/1000000000.0); // to ros time stamp
-      
-      cloud->header.stamp = timestamp/1000.0; // to ros time stamp
+      ros::Time now = ros::Time::now();
+      cloud->header.stamp = now.toNSec() / 1000.0;
       ROS_DEBUG("[%d]:%ld us", handle, timestamp);
     }
     cloud->width += storage_packet.point_num;


### PR DESCRIPTION
For me the timestamp was wrong and not useable with other publishers like TF.