### PR TITLE
Join thread fix

### DIFF
--- a/livox_ros_driver/livox_ros_driver/lds_lvx.cpp
+++ b/livox_ros_driver/livox_ros_driver/lds_lvx.cpp
@@ -55,6 +55,9 @@ LdsLvx::~LdsLvx() {
   if (packets_of_frame_.packet != nullptr) {
     delete[] packets_of_frame_.packet;
   }
+  if (t_read_lvx_->joinable()) {
+    t_read_lvx_->join();
+  }
 }
 
 void LdsLvx::PrepareExit(void) {


### PR DESCRIPTION
I am using this package to develop a lvx parser (without ROS). This should be added to the `LdsLvx` class. The thread is not joined and it ultimately results in a segfault. 