### PR TITLE
Add rosparam for modifying frame_id in rosmsg

### DIFF
--- a/livox_ros_driver/livox_ros_driver/lddc.cpp
+++ b/livox_ros_driver/livox_ros_driver/lddc.cpp
@@ -46,9 +46,9 @@ typedef pcl::PointCloud<pcl::PointXYZI> PointCloud;
 /** Lidar Data Distribute Control
  * ----------------------------------------------------------------*/
 Lddc::Lddc(int format, int multi_topic, int data_src, int output_type,
-           double frq)
+           double frq, std::string frame_id)
     : transfer_format_(format), use_multi_topic_(multi_topic),
-      data_src_(data_src), output_type_(output_type), publish_frq_(frq) {
+      data_src_(data_src), output_type_(output_type), publish_frq_(frq), frame_id_(frame_id) {
 
   publish_interval_ms_ = 1000 / publish_frq_;
   lds_ = nullptr;
@@ -95,7 +95,7 @@ uint32_t Lddc::PublishPointcloud2(LidarDataQueue *queue, uint32_t packet_num,
   uint32_t published_packet = 0;
   sensor_msgs::PointCloud2 cloud;
 
-  cloud.header.frame_id = "livox_frame";
+  cloud.header.frame_id = frame_id_;
   cloud.height = 1;
   cloud.width = 0;
 
@@ -218,7 +218,7 @@ uint32_t Lddc::PublishPointcloudData(LidarDataQueue *queue, uint32_t packet_num,
 
   /* init point cloud data struct */
   PointCloud::Ptr cloud(new PointCloud);
-  cloud->header.frame_id = "livox_frame";
+  cloud->header.frame_id = frame_id_;
   // cloud->header.stamp = ros::Time::now();
   cloud->height = 1;
   cloud->width = 0;
@@ -316,7 +316,7 @@ uint32_t Lddc::PublishCustomPointcloud(LidarDataQueue *queue,
 
   livox_ros_driver::CustomMsg livox_msg;
 
-  livox_msg.header.frame_id = "livox_frame";
+  livox_msg.header.frame_id = frame_id_;
   livox_msg.header.seq = msg_seq;
   ++msg_seq;
   // livox_msg.header.stamp = ros::Time::now();
@@ -418,7 +418,7 @@ uint32_t Lddc::PublishImuData(LidarDataQueue *queue, uint32_t packet_num,
   uint32_t published_packet = 0;
 
   sensor_msgs::Imu imu_data;
-  imu_data.header.frame_id = "livox_frame";
+  imu_data.header.frame_id = frame_id_;
 
   uint8_t data_source = lds_->lidars_[handle].data_src;
   StoragePacket storage_packet;

--- a/livox_ros_driver/livox_ros_driver/lddc.h
+++ b/livox_ros_driver/livox_ros_driver/lddc.h
@@ -41,7 +41,7 @@ typedef enum {
 
 class Lddc {
 public:
-  Lddc(int format, int multi_topic, int data_src, int output_type, double frq);
+  Lddc(int format, int multi_topic, int data_src, int output_type, double frq, std::string frame_id);
   ~Lddc();
 
   int RegisterLds(Lds *lds);
@@ -78,6 +78,7 @@ private:
   uint8_t data_src_;
   uint8_t output_type_;
   double publish_frq_;
+  std::string frame_id_;
   int32_t publish_interval_ms_;
   ros::Publisher *private_pub_[kMaxSourceLidar];
   ros::Publisher *global_pub_;

--- a/livox_ros_driver/livox_ros_driver/livox_ros_driver.cpp
+++ b/livox_ros_driver/livox_ros_driver/livox_ros_driver.cpp
@@ -65,16 +65,18 @@ int main(int argc, char **argv) {
   int data_src = kSourceRawLidar;
   double publish_freq = 20.0; /* Hz */
   int output_type = kOutputToRos;
+  std::string frame_id = "livox_frame";
 
   livox_node.getParam("xfer_format", xfer_format);
   livox_node.getParam("multi_topic", multi_topic);
   livox_node.getParam("data_src", data_src);
   livox_node.getParam("publish_freq", publish_freq);
   livox_node.getParam("output_data_type", output_type);
+  livox_node.getParam("frame_id", frame_id);
 
   /** Lidar data distribute control and lidar data source set */
   Lddc *lddc =
-      new Lddc(xfer_format, multi_topic, data_src, output_type, publish_freq);
+      new Lddc(xfer_format, multi_topic, data_src, output_type, publish_freq, frame_id);
   lddc->SetRosNode(&livox_node);
 
   int ret = 0;


### PR DESCRIPTION
The frame_id is fixed and there was a problem when installing multiple units.
This PR allows to change frame_id.