### PR TITLE
fix: add launch copy command in CMakeLists.txt

### DIFF
--- a/livox_ros_driver/CMakeLists.txt
+++ b/livox_ros_driver/CMakeLists.txt
@@ -212,6 +212,10 @@ install(TARGETS ${PROJECT_NAME}_node
 	RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 	)
 
+install(DIRECTORY launch/
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+	)
+
 #---------------------------------------------------------------------------------------
 # end of CMakeList.txt
 #---------------------------------------------------------------------------------------


### PR DESCRIPTION
I faced one issue when I use this ros driver as "installed" version. (which is generated by `catkin_make install` command).
The issue is installed version doesn't copy launch directory from the source so I couldn't use roslaunch command.

In this branch, I added some lines in CMakeList.txt for copying launch directory. This would be helpful for someone who wants to use just deployed ros driver.