### PR TITLE
Fix double free of global_pub_

### DIFF
--- a/livox_ros_driver/livox_ros_driver/lddc.cpp
+++ b/livox_ros_driver/livox_ros_driver/lddc.cpp
@@ -66,7 +66,7 @@ Lddc::~Lddc() {
   }
 
   if (global_imu_pub_) {
-    delete global_pub_;
+    delete global_imu_pub_;
   }
 
   if (lds_) {


### PR DESCRIPTION
The pointer `global_pub_` seems to be freed twice and `global_imu_pub_` does not be freed.
This issue is detected by cppcheck.