### PR TITLE
Fix copy-paste error in timesync

### DIFF
--- a/livox_ros_driver/timesync/timesync.cpp
+++ b/livox_ros_driver/timesync/timesync.cpp
@@ -98,7 +98,7 @@ void TimeSync::StopTimesync() {
     t_poll_state_ = nullptr;
   }
 
-  if (t_poll_state_) {
+  if (t_poll_data_) {
     t_poll_data_->join();
     t_poll_data_ = nullptr;
   }


### PR DESCRIPTION
`t_poll_state_` would be `t_poll_data_` in `timesync.cpp`.