### PR TITLE
add config install setting

### DIFF
--- a/livox_ros_driver/CMakeLists.txt
+++ b/livox_ros_driver/CMakeLists.txt
@@ -212,12 +212,12 @@ install(TARGETS ${PROJECT_NAME}_node
 	RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 	)
 
-install(DIRECTORY launch/
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+install(DIRECTORY
+  launch
+  config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 	)
 
 #---------------------------------------------------------------------------------------
 # end of CMakeList.txt
 #---------------------------------------------------------------------------------------
-
-


### PR DESCRIPTION
I added a config directory to install target directory.
This is needed when searching rviz config file from pkg prefix path.