### PR TITLE
[fix] The unit of linear_acceleration is m/s^2

### DIFF
--- a/livox_ros_driver/livox_ros_driver/lddc.cpp
+++ b/livox_ros_driver/livox_ros_driver/lddc.cpp
@@ -504,9 +504,9 @@ uint32_t Lddc::PublishImuData(LidarDataQueue *queue, uint32_t packet_num,
   imu_data.angular_velocity.x = imu->gyro_x;
   imu_data.angular_velocity.y = imu->gyro_y;
   imu_data.angular_velocity.z = imu->gyro_z;
-  imu_data.linear_acceleration.x = imu->acc_x;
-  imu_data.linear_acceleration.y = imu->acc_y;
-  imu_data.linear_acceleration.z = imu->acc_z;
+  imu_data.linear_acceleration.x = imu->acc_x * gravity;
+  imu_data.linear_acceleration.y = imu->acc_y * gravity;
+  imu_data.linear_acceleration.z = imu->acc_z * gravity;
 
   QueuePopUpdate(queue);
   ++published_packet;

--- a/livox_ros_driver/livox_ros_driver/lddc.h
+++ b/livox_ros_driver/livox_ros_driver/lddc.h
@@ -61,6 +61,7 @@ class Lddc {
 
   void SetRosPub(ros::Publisher *pub) { global_pub_ = pub; };
   void SetPublishFrq(uint32_t frq) { publish_frq_ = frq; }
+  const float gravity = 9.8; // m/s^2
 
   Lds *lds_;
 


### PR DESCRIPTION
### Summary
  The unit of linear_acceleration in the imu is G, but it should be m/s^2 according to the [wiki](http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/Imu.html).
>  Accelerations should be in m/s^2 (not in g's), and rotational velocity should be in rad/sec

### Detail
* Change files
  - modified:   livox_ros_driver/lddc.cpp
  - modified:   livox_ros_driver/lddc.h
 
*  Refs #63 

* Effect
  Comparison of `rostopic echo /livox/imu_XXXXX` in bag file converted by `lvx_to_rosbag.launch` from same lvx file.

**Before**

```
---
header:
  seq: 0
  stamp:
    secs: 1628129261
    nsecs: 482877970
  frame_id: "livox_frame"
orientation:
  x: 0.0
  y: 0.0
  z: 0.0
  w: 0.0
orientation_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
angular_velocity:
  x: -0.021623685956
  y: -0.0181506872177
  z: -0.0124202724546
angular_velocity_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
linear_acceleration:
  x: 0.0482514984906
  y: -0.00931103434414
  z: 0.876538217068
linear_acceleration_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
---
```
**After**

```
---
header:
  seq: 0
  stamp:
    secs: 1628129299
    nsecs: 774994612
  frame_id: "livox_frame"
orientation:
  x: 0.0
  y: 0.0
  z: 0.0
  w: 0.0
orientation_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
angular_velocity:
  x: 0.0199216287583
  y: -0.0415865033865
  z: 0.547908842564
angular_velocity_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
linear_acceleration:
  x: 0.0861642286181
  y: 0.872362732887
  z: 9.27106189728
linear_acceleration_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
---
```
