### PR TITLE
修复一些个人使用中遇到的问题

### DIFF
--- a/livox_ros_driver/CMakeLists.txt
+++ b/livox_ros_driver/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 #---------------------------------------------------------------------------------------
 # Compiler config
 #---------------------------------------------------------------------------------------
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/livox_ros_driver/livox_ros_driver/lddc.cpp
+++ b/livox_ros_driver/livox_ros_driver/lddc.cpp
@@ -340,11 +340,11 @@ uint32_t Lddc::PublishPointcloudData(LidarDataQueue *queue, uint32_t packet_num,
 
   ros::Publisher *p_publisher = Lddc::GetCurrentPublisher(handle);
   if (kOutputToRos == output_type_) {
-    p_publisher->publish(cloud);
+    p_publisher->publish(*cloud);
   } else {
     if (bag_ && enable_lidar_bag_) {
       bag_->write(p_publisher->getTopic(), ros::Time(timestamp / 1000000000.0),
-          cloud);
+          *cloud);
     }
   }
   if (!lidar->data_is_pubulished) {

--- a/livox_ros_driver/timesync/timesync.h
+++ b/livox_ros_driver/timesync/timesync.h
@@ -25,6 +25,7 @@
 #ifndef TIMESYNC_TIMESYNC_H_
 #define TIMESYNC_TIMESYNC_H_
 
+#include <memory>
 #include <thread>
 #include "comm_device.h"
 #include "comm_protocol.h"


### PR DESCRIPTION
高版本log4cxx自动依赖std::shared_mutex（C++17）而不是boost中的同名类型。将CMAKE_CXX_STANDARD改为17可解决。

```
/usr/include/log4cxx/boost-std-configuration.h:10:18: 错误：‘shared_mutex’不是命名空间‘std’中的一个类型名
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: 附注：‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
```

timesync.h未引用memory标准库。

```
~/ws_livox/src/livox_ros_driver/timesync/timesync.h:81:8: 错误：‘shared_ptr’ in namespace ‘std’ does not name a template type
   81 |   std::shared_ptr<std::thread> t_poll_state_;
      |        ^~~~~~~~~~
~/ws_livox/src/livox_ros_driver/timesync/timesync.h:33:1: 附注：‘std::shared_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   32 | #include "user_uart.h"
  +++ |+#include <memory>
   33 | 
```

ros::Publisher、rosbag::Bag不接受指针作为输入msg。解指针。

```
/opt/ros/melodic/include/ros/message_traits.h:142:14: 错误：‘const class std::shared_ptr<pcl::PointCloud<pcl::PointXYZI> >’ has no member named ‘__getDataType’
  142 |     return m.__getDataType().c_str();
      |            ~~^~~~~~~~~~~~~
```