### PR TITLE
Publishing PointCloud2 with ROS timestamp

### DIFF
--- a/livox_ros_driver/livox_ros_driver/lddc.cpp
+++ b/livox_ros_driver/livox_ros_driver/lddc.cpp
@@ -203,7 +203,8 @@ uint32_t Lddc::PublishPointcloud2(LidarDataQueue *queue, uint32_t packet_num,
     }
     /** Use the first packet timestamp as pointcloud2 msg timestamp */
     if (!published_packet) {
-      cloud.header.stamp = ros::Time(timestamp / 1000000000.0);
+      //cloud.header.stamp = ros::Time(timestamp / 1000000000.0);
+      cloud.header.stamp = ros::Time::now();
     }
     uint32_t single_point_num = storage_packet.point_num * echo_num;
 


### PR DESCRIPTION
This pull request fixes the fact that point clouds in ROS are not published with correct ROS time.
